### PR TITLE
Sync with new makerancidconf

### DIFF
--- a/share/views/plugin/rancid/device_details.tt
+++ b/share/views/plugin/rancid/device_details.tt
@@ -1,3 +1,7 @@
+[% IF session.rancid_display %]
 <a href="[% settings.plugin_rancid.location.replace('\%GROUP\%',rancidgroup).replace('\%DEVICE\%',ranciddevice) %]"
   [% ' target="_blank"' UNLESS settings.plugin_rancid.open_in_same_window %]
 >View Configuration <i class="icon-circle-arrow-right"></i></a>
+[% ELSE %]
+<i>No RANCID backup done for this device.</i>
+[% END %]


### PR DESCRIPTION
Check options by_hostname and by_ip with the check_acl function because the current function doesn't take in count the ACL that contains others ACL

+ doesn't display the link to RANCID on device that have been exclude of the RANCID export.